### PR TITLE
swapping eventbrite iFrame with button to eventbrite

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,14 +36,14 @@
 <div class="speaker-talks">
     <div class="slider">
         <div class="speaker snook">
-            
+
             <header>
                 <div class="speaker-photo">
                     <img src="/images/speakers/snook.jpg" alt="Jonathan Snook">
                 </div>
                 <div class="title">
                     <h1>The Future is in pieces</h1>
-                    <h2>by Jonathan Snook</h2>     
+                    <h2>by Jonathan Snook</h2>
                 </div>
             </header>
 
@@ -58,7 +58,7 @@
 
         </div>
         <div class="speaker fisher">
-            
+
             <header>
                 <div class="speaker-photo">
                     <img src="/images/speakers/fisher.jpg" alt="Lynn Fisher">
@@ -79,20 +79,20 @@
         </div>
 
         <div class="speaker sauve">
-            
+
             <header>
                 <div class="speaker-photo">
                     <img src="/images/speakers/sauve.jpg" alt="Chris Sauvé">
                 </div>
                 <div class="title">
                     <h1>Content-driven Layouts with Flexbox</h1>
-                    <h2>by Chris Sauvé</h2>                
+                    <h2>by Chris Sauvé</h2>
                 </div>
             </header>
 
             <p>Handling variable or unknown content in a layout can be tricky. Our current responsive layout techniques generally have unspoken assumptions that can easily be broken by changes in content, internationalization, and a collection of other unexpected adjustments to what needs to be laid out.</p>
             <p>This talk will discuss how we can use Flexbox-driven layouts to overcome these challenges - how we can learn to stop worrying about our traditional, top-down layout techniques and love the content-driven layouts that Flexbox affords. We'll go over the key parts of the Flexbox spec that let the container respond to the content, instead of the other way around, and how we can build amazingly responsive layouts without a single media query or fixed width.</p>
-            
+
 
         </div>
 
@@ -107,7 +107,7 @@
                     <h2>by David Clark</h2>
                 </div>
             </header>
-                
+
             <p>PostCSS is a parser and stringifier that makes it easy to create new CSS tools with JavaScript. It can power alternatives to Sass and Less - language extensions - but it can also power an unlimited variety of other tools, doing other things. With its simple API, sourcemap support, and modular ecosystem, PostCSS brings important new powers and possibilities to frontend developers.</p>
             <p>In the CSS world, we're not accustomed to wielding such power - but there's no need to be afraid. After clarifying what PostCSS is (and what it's not), dispelling some misleading rumors, and re-framing the conversation, David will expose you to different types of tools that have been built with PostCSS, and show how you could start building your own.</p>
 
@@ -124,7 +124,7 @@
                     <h2>by Keith J. Grant</h2>
                 </div>
             </header>
-                
+
             <p>A well-organized style sheet is written in layers: the more general styles appear first, and lay the foundation for the more specific styles later. Let's explore some strategies for improving our general styles, so the specific styles are easier (or unnecessary!) to write. This talk will look at some ways to leverage the cascade instead of fighting or avoiding it, how to build layouts that behave responsively without media queries, and generally reduce the need for more and more specific styles later in our style sheet.</p>
 
         </div>
@@ -140,7 +140,7 @@
                     <h2>by Dhruv Patel</h2>
                 </div>
             </header>
-                
+
             <p>Animation capabilities have improved dramatically across the web driven by CSS transitions, hardware accelerated transforms, and standards such as JS Web Animations. Given the early state of UI motion design, it's only natural that designers are tempted to add animation as visual flair, not unlike, drop shadows or bevels. We will be creating few UI and layout projects that will help you learn some of the awesome new design techniques that CSS3 brings to the table. Animated user interfaces can be powerful - so powerful that they offer a competitive advantage to their products, regardless of platform.</p>
 
         </div>
@@ -156,7 +156,7 @@
                     <h2>by Brian Bell</h2>
                 </div>
             </header>
-                
+
             <p>Modern client-side tools are abundant and powerful, with pre-processors being one of the greatest advancements to date for CSS. However, in practice, these tools are only as smart as the client-side architects who wield them. We will look at several techniques for how Sass can help you apply a modular way of thinking to your site's CSS file structure that can be configured to support both cutting edge responsive web development and legacy codebases.</p>
 
         </div>
@@ -172,7 +172,7 @@
                     <h2>by David Newton</h2>
                 </div>
             </header>
-                
+
             <p>I will be speaking about the web's hunger for more, bigger, and higher-resolution images, and the performance problem this creates. I'll give a brief history of the new (and occasionally controversial) responsive images specification, and discuss some other exciting new standards that are on the horizon. In addition to responsive image solutions, I'll discuss techniques for improving image loading performance in general, including optimization and pre-processing, deferred loading, image format choice, caching, and use of CDNs. Attendees can expect concrete examples of how the new <code>srcset</code> and `sizes` attributes and `picture` element work, and to learn how they can use responsive and responsible images right now to improve performance and deliver the best possible experience to their users.</p>
 
         </div>
@@ -188,7 +188,7 @@
                     <h2>by Brad Westfall</h2>
                 </div>
             </header>
-                
+
             <p>While separation of components from layout is a well known strategy, sometimes practice is more difficult than theory. We'll cover the strategies for building the structure of components with re-usable parts and achieving separation of components from their layout. Also, grid systems are increasingly popular these days, but not all layouts require them. We'll explore some layout strategies without grid systems so you'll have the freedom to choose when to use a grid and when to go custom.</p>
         </div>
 
@@ -199,7 +199,7 @@
 </div>
 
 <div class="page">
-    
+
     <section class="hero">
         <div>
 
@@ -240,26 +240,28 @@
                     make sense of the parts you struggle with. We'll have intermediate to
                     advanced talks from CSS experts all day! Lunch is provided.
                 </p>
-                <p class="date">CSS Day is Saturday, December 5th 2015 at Infusionsoft.</p> 
+                <p class="date">CSS Day is Saturday, December 5th 2015 at Infusionsoft.</p>
                 <p>
                     For Hotel Accommodations and other event details, see our <a href="/venue.html">Venue Details</a> page
                 </p>
-                
+
             </div>
         </section>
 
         <section class="panel tickets" id="tickets">
             <div>
                 <h1>Tickets</h1>
-                <p class="em">Tickets will be available June 1st at 4:00 PM</p> 
-                <div style="width:100%; text-align:left;"><iframe  src="//eventbrite.com/tickets-external?eid=6612142095&ref=etckt" frameborder="0" height="450" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe><div style="font-family:Helvetica, Arial; font-size:10px; padding:5px 0 5px; margin:2px; width:100%; text-align:left;" ><a class="powered-by-eb" style="color: #dddddd; text-decoration: none;" target="_blank" href="http://www.eventbrite.com/r/etckt">Powered by Eventbrite</a></div></div>
+                <p class="em">Tickets will be available June 1st at 4:00 PM</p>
+                <div class="spash">
+                    <a class="button" href="http://cssday.eventbrite.com">Get Tickets from Eventbrite</a>
+                </div>
             </div>
         </section>
 
         <section class="panel speakers" id="speakers">
             <div>
 
-  
+
                 <div class="speaker">
                     <div class="speaker-photo">
                         <img src="/images/speakers/snook.jpg" alt="Jonathan Snook">
@@ -267,7 +269,7 @@
                             <div>Jonathan Snook</div>
                         </div>
                     </div>
-                    <div class="name">The Future is in pieces</div>                    
+                    <div class="name">The Future is in pieces</div>
                     <div class="work">Creator of SMACSS <a href="http://twitter.com/snookca"><i class="fa fa-twitter"></i> snookca</a></div>
                 </div>
 
@@ -278,8 +280,8 @@
                             <div>Lynn Fisher</div>
                         </div>
                     </div>
-                    <div class="name">Illustration with CSS</div>                    
-                    <div class="work">&amp;yet <a href="http://twitter.com/lynnandtonic"><i class="fa fa-twitter"></i> lynnandtonic</a></div>                    
+                    <div class="name">Illustration with CSS</div>
+                    <div class="work">&amp;yet <a href="http://twitter.com/lynnandtonic"><i class="fa fa-twitter"></i> lynnandtonic</a></div>
                 </div>
 
                 <div class="speaker">
@@ -289,8 +291,8 @@
                             <div>Chris Sauvé</div>
                         </div>
                     </div>
-                    <div class="name">Content-driven Layouts with Flexbox</div>                    
-                    <div class="work">Shopify <a href="http://twitter.com/_lemonmade"><i class="fa fa-twitter"></i> _lemonmade</a></div>                    
+                    <div class="name">Content-driven Layouts with Flexbox</div>
+                    <div class="work">Shopify <a href="http://twitter.com/_lemonmade"><i class="fa fa-twitter"></i> _lemonmade</a></div>
                 </div>
 
                 <div class="speaker">
@@ -300,10 +302,10 @@
                             <div>David Clark</div>
                         </div>
                     </div>
-                    <div class="name">Exploring New Possibilities with PostCSS</div>                  
-                    <div class="work"><a href="http://twitter.com/davidtheclark"><i class="fa fa-twitter"></i> davidtheclark</a></div>                    
+                    <div class="name">Exploring New Possibilities with PostCSS</div>
+                    <div class="work"><a href="http://twitter.com/davidtheclark"><i class="fa fa-twitter"></i> davidtheclark</a></div>
                 </div>
-      
+
                 <div class="speaker">
                     <div class="speaker-photo">
                         <img src="/images/speakers/grant.jpg" alt="Keith J. Grant">
@@ -311,8 +313,8 @@
                             <div>Keith J. Grant</div>
                         </div>
                     </div>
-                    <div class="name"><em>Rethinking Base Styles</em></div>                    
-                    <div class="work">Author of <em>CSS in Action</em><a href="http://twitter.com/keithjgrant"><i class="fa fa-twitter"></i> keithjgrant</a></div>                    
+                    <div class="name"><em>Rethinking Base Styles</em></div>
+                    <div class="work">Author of <em>CSS in Action</em><a href="http://twitter.com/keithjgrant"><i class="fa fa-twitter"></i> keithjgrant</a></div>
                 </div>
 
                 <div class="speaker">
@@ -322,8 +324,8 @@
                             <div>Dhruv Patel</div>
                         </div>
                     </div>
-                    <div class="name">Principles in UI Animation for Developers</div>                    
-                    <div class="work">Founder of Convrrt <a href="http://twitter.com/sylphdesign"><i class="fa fa-twitter"></i> sylphdesign</a></div>                    
+                    <div class="name">Principles in UI Animation for Developers</div>
+                    <div class="work">Founder of Convrrt <a href="http://twitter.com/sylphdesign"><i class="fa fa-twitter"></i> sylphdesign</a></div>
                 </div>
 
                 <div class="speaker">
@@ -333,8 +335,8 @@
                             <div>Brian Bell</div>
                         </div>
                     </div>
-                    <div class="name">Using Sass to Avoid Turning Your Codebase into a Box of Bees</div>                    
-                    <div class="work">The Nerdery <a href="http://twitter.com/bbellx"><i class="fa fa-twitter"></i> bbellx</a></div>                    
+                    <div class="name">Using Sass to Avoid Turning Your Codebase into a Box of Bees</div>
+                    <div class="work">The Nerdery <a href="http://twitter.com/bbellx"><i class="fa fa-twitter"></i> bbellx</a></div>
                 </div>
 
                 <div class="speaker">
@@ -344,8 +346,8 @@
                             <div>David Newton</div>
                         </div>
                     </div>
-                    <div class="name">Improving performance with responsive (and responsible!) images</div>                    
-                    <div class="work"><a href="http://twitter.com/newtron"><i class="fa fa-twitter"></i> newtron</a></div>                    
+                    <div class="name">Improving performance with responsive (and responsible!) images</div>
+                    <div class="work"><a href="http://twitter.com/newtron"><i class="fa fa-twitter"></i> newtron</a></div>
                 </div>
 
                 <div class="speaker">
@@ -355,8 +357,8 @@
                             <div>Brad Westfall</div>
                         </div>
                     </div>
-                    <div class="name">Component Independence and Layout Strategies</div>                    
-                    <div class="work">AZPixels <a href="http://twitter.com/bradwestfall"><i class="fa fa-twitter"></i> bradwestfall</a></div>                    
+                    <div class="name">Component Independence and Layout Strategies</div>
+                    <div class="work">AZPixels <a href="http://twitter.com/bradwestfall"><i class="fa fa-twitter"></i> bradwestfall</a></div>
                 </div>
 
                 <!-- <div class="speaker stub">


### PR DESCRIPTION
iFrame is causing odd redirect loop in safari on iOS.

Sorry about the diff nightmare, my sublime text removes blank spaces in line endings. See lines 254-257 for actual diff. 
![cssday_io__dec__5th__2015_in_phoenix__arizona_1](https://cloud.githubusercontent.com/assets/1133646/10253341/c4aef956-68f1-11e5-9f58-aeb1503dd409.png)
![cssday_io__dec__5th__2015_in_phoenix__arizona](https://cloud.githubusercontent.com/assets/1133646/10253342/c4b1a02a-68f1-11e5-820a-1f30b7115f4e.png)
